### PR TITLE
improve tests

### DIFF
--- a/core/include/alibabacloud/core/ServiceRequest.h
+++ b/core/include/alibabacloud/core/ServiceRequest.h
@@ -30,6 +30,11 @@ public:
   typedef std::string ParameterValueType;
   typedef std::map<ParameterNameType, ParameterValueType> ParameterCollection;
 
+  ServiceRequest(const std::string &product, const std::string &version);
+  ServiceRequest(const ServiceRequest &other);
+  ServiceRequest(ServiceRequest &&other);
+  ServiceRequest &operator=(const ServiceRequest &other);
+  ServiceRequest &operator=(ServiceRequest &&other);
   virtual ~ServiceRequest();
 
   const char *content() const;
@@ -54,12 +59,6 @@ public:
   void setBodyParameter(const ParameterNameType &name, const ParameterValueType &value);
 
 protected:
-  ServiceRequest(const std::string &product, const std::string &version);
-  ServiceRequest(const ServiceRequest &other);
-  ServiceRequest(ServiceRequest &&other);
-  ServiceRequest &operator=(const ServiceRequest &other);
-  ServiceRequest &operator=(ServiceRequest &&other);
-
   void addParameter(const ParameterNameType &name,
                     const ParameterValueType &value);
   ParameterValueType parameter(const ParameterNameType &name) const;

--- a/test/core/servicerequest_ut.cc
+++ b/test/core/servicerequest_ut.cc
@@ -17,10 +17,12 @@ namespace {
     {}
     explicit TestServiceRequest(const ServiceRequest &other):
       ServiceRequest(other)
-    {}
+    {
+    }
     explicit TestServiceRequest(ServiceRequest &&other):
       ServiceRequest(other)
-    {}
+    {
+    }
 
     using ServiceRequest::addParameter;
     using ServiceRequest::coreParameter;
@@ -102,5 +104,22 @@ namespace {
     sr1.setReadTimeout(22233);
     EXPECT_TRUE(sr1.connectTimeout() == 1234);
     EXPECT_TRUE(sr1.readTimeout() == 22233);
+  }
+
+  TEST(ServiceRequest, other){
+    ServiceRequest one("one", "1.0");
+    EXPECT_EQ("one", one.product());
+
+    ServiceRequest two("two", "1.0");
+    EXPECT_EQ("two", two.product());
+
+    ServiceRequest three = one;
+    EXPECT_EQ("one", three.product());
+
+    ServiceRequest four(two);
+    EXPECT_EQ("two" , four.product());
+
+    ServiceRequest &&five(move(two));
+    EXPECT_EQ("two" , five.product());
   }
 }

--- a/test/function_test/core/locationclient_ft.cc
+++ b/test/function_test/core/locationclient_ft.cc
@@ -131,9 +131,11 @@ TEST(LocationClient, callable)
   configuration.setConnectTimeout(100000);
   configuration.setReadTimeout(100000);
   Model::DescribeEndpointsRequest req;
+  req.setMethod(HttpRequest::Method::Get);
   req.setId("cn-hangzhou");
   req.setServiceCode("ecs");
   req.setType("openAPI");
+  req.setBodyParameter("foo", "var");
 
   LocationClient client(key, secret, configuration);
   LocationClient::DescribeEndpointsOutcomeCallable cb = client.describeEndpointsCallable(req);


### PR DESCRIPTION
location 请求设置 Get 方法的原因是在之前的测试运行结果中有报错，错误信息是由 location 服务接口回调的“不支持的请求方式”。
其他改动是为了提高测试覆盖率。