### PR TITLE
Fix readme dependencies uuid-devel

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -46,7 +46,7 @@ Alibaba Cloud SDK for C++ 让您不用复杂编程即可访问云服务器、负
 
 ```bash
 # use yum
-yum install jsoncpp-devel openssl-devel uuid-devel libcurl-devel
+yum install jsoncpp-devel openssl-devel libuuid-devel libcurl-devel
 
 # use dnf
 sudo dnf install libcurl-devel openssl-devel libuuid-devel libjsoncpp-devel

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you have any problem while using Alibaba Cloud SDK for C++, please submit an 
 
 ```bash
 # use yum
-yum install jsoncpp-devel openssl-devel uuid-devel libcurl-devel
+yum install jsoncpp-devel openssl-devel libuuid-devel libcurl-devel
 
 # use dnf
 sudo dnf install libcurl-devel openssl-devel libuuid-devel libjsoncpp-devel


### PR DESCRIPTION
core/src/Utils.cc用到了libuuid-devel这个库，引用方式是`#include <uuid/uuid.h>`。

yum有两个类似的库，一个是`libuuid-devel`，另一个是`uuid-devel`。如果是`uuid-devel`，则引用方式应该是`#include <uuid.h>`，这里实际引用的应该是`libuuid-devel`。

对应关系如下：
`libuuid-devel` 对应 `#include <uuid/uuid.h>`
`uuid-devel` 对应 `#include <uuid.h>`